### PR TITLE
correlations are also computed by run now

### DIFF
--- a/RetinoMaps/rest/correlations/connectome-workbench_dense_full_corr_by_hemi.sh
+++ b/RetinoMaps/rest/correlations/connectome-workbench_dense_full_corr_by_hemi.sh
@@ -4,7 +4,8 @@
 # Goal of the script:
 # Compute full correlation by vertex intra-hemispherically using Connectome Workbench v. 2.1
 # Outputs are parcellated using the mean method and masked for supplementary info visualizations
-# 
+# Now we also compute correlations for each run separately so we can exclude some runs at a later stage of the pipeline
+#
 # Written by Marco Bedini (marco.bedini@univ-amu.fr)
 #####################################################
 
@@ -16,126 +17,141 @@ ATLAS="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
 for i in 01 02 03 04 05 06 07 08 09 11 12 13 14 17 20 21 22 23 24 25;
 do
 
-SEED_DIR="$TASK_RESULTS/sub-${i}/91k/rest/seed"
-OUT_DIR="$TASK_RESULTS/sub-${i}/91k/rest/corr/full_corr/workbench_full_corr/by_hemi"
+    SEED_DIR="$TASK_RESULTS/sub-${i}/91k/rest/seed"
+    OUT_DIR="$TASK_RESULTS/sub-${i}/91k/rest/corr/full_corr/by_hemi"
 
-## Make sure all files are accessible
-chmod -Rf 771 "$SEED_DIR"
-chgrp -Rf 327 "$SEED_DIR"
+    ## Make sure all files are accessible
+    chmod -Rf 771 "$SEED_DIR"
+    chgrp -Rf 327 "$SEED_DIR"
 
-mkdir -p "$OUT_DIR"
+    mkdir -p "$OUT_DIR"
 
-	for ROI in mPCS sPCS iPCS sIPS iIPS hMT+ VO LO V3AB V3 V2 V1;
-	do
-	  for HEMI in lh rh;
-	  do
+    for ROI in mPCS sPCS iPCS sIPS iIPS hMT+ VO LO V3AB V3 V2 V1;
+    do
+        for HEMI in lh rh;
+        do
+            # Loop over individual runs + concatenated run
+            for RUN in run-01 run-02 "";
+            do
 
-	    if [ "$HEMI" = "lh" ]; then
-	      ROI_FLAG="-left-roi"
-	    else
-	      ROI_FLAG="-right-roi"
-	    fi
+                # Build run-dependent filename tag
+                if [ -n "$RUN" ]; then
+                    RUN_TAG="_${RUN}"
+                else
+                    RUN_TAG=""
+                fi
 
-	    ROI_FILE="$SEED_DIR/sub-${i}_91k_intertask_Sac-Pur-pRF_${HEMI}_${ROI}.shape.gii"
+                if [ "$HEMI" = "lh" ]; then
+                    ROI_FLAG="-left-roi"
+                else
+                    ROI_FLAG="-right-roi"
+                fi
 
-	    # Full correlation
-	    wb_command -cifti-correlation \
-	    	"$TASK_RESULTS/sub-${i}/91k/rest/timeseries/sub-${i}_ses-01_task-rest_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii" \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii" \
-	    	-roi-override $ROI_FLAG "$ROI_FILE" \
-	    	-mem-limit 20
+                ROI_FILE="$SEED_DIR/sub-${i}_91k_intertask_Sac-Pur-pRF_${HEMI}_${ROI}.shape.gii"
 
-	    # Fisher-z
-	    wb_command -cifti-correlation \
-	    	"$TASK_RESULTS/sub-${i}/91k/rest/timeseries/sub-${i}_ses-01_task-rest_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii" \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii" \
-	    	-roi-override $ROI_FLAG "$ROI_FILE" \
-	    	-fisher-z -mem-limit 20
+                TS_FILE="$TASK_RESULTS/sub-${i}/91k/rest/timeseries/sub-${i}_ses-01_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii"
 
-	    # Average within seed ROI
-	    wb_command -cifti-average-dense-roi \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
-	    	$ROI_FLAG "$ROI_FILE" \
-	    	-cifti "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii"
+                # Full correlation
+                wb_command -cifti-correlation \
+                    "$TS_FILE" \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii" \
+                    -roi-override $ROI_FLAG "$ROI_FILE" \
+                    -mem-limit 50
 
-	    wb_command -cifti-average-dense-roi \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
-	    	$ROI_FLAG "$ROI_FILE" \
-	    	-cifti "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii"
+                # Fisher-z
+                wb_command -cifti-correlation \
+                    "$TS_FILE" \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii" \
+                    -roi-override $ROI_FLAG "$ROI_FILE" \
+                    -fisher-z -mem-limit 50
 
-	    # Parcellate targets
-	    wb_command -cifti-parcellate \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
-	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated.pscalar.nii" \
-	    	-method MEAN -only-numeric;
+                # Average within seed ROI
+                wb_command -cifti-average-dense-roi \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+                    $ROI_FLAG "$ROI_FILE" \
+                    -cifti "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii"
 
-	    wb_command -cifti-parcellate \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
-	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.pscalar.nii" \
-	    	-method MEAN -only-numeric;
+                wb_command -cifti-average-dense-roi \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+                    $ROI_FLAG "$ROI_FILE" \
+                    -cifti "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii"
 
-	    # Parcellate excluding outliers
-	    wb_command -cifti-parcellate \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
-	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
-	    	-method MEAN -only-numeric -exclude-outliers 3 3;
+                # Parcellate targets
+                wb_command -cifti-parcellate \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+                    "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated.pscalar.nii" \
+                    -method MEAN -only-numeric
 
-	    wb_command -cifti-parcellate \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
-	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
-	    	-method MEAN -only-numeric -exclude-outliers 3 3;
+                wb_command -cifti-parcellate \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+                    "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.pscalar.nii" \
+                    -method MEAN -only-numeric
 
-		# Parcellate targets using -legacy-mode (just to check if different behavior on sub-25 mPCS)
-	    wb_command -cifti-parcellate \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
-	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
-	    	-method MEAN -only-numeric -legacy-mode;
+                # Parcellate excluding outliers
+                wb_command -cifti-parcellate \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+                    "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
+                    -method MEAN -only-numeric -exclude-outliers 3 3
 
-	    wb_command -cifti-parcellate \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
-	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
-	    	-method MEAN -only-numeric -legacy-mode;
+                wb_command -cifti-parcellate \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+                    "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
+                    -method MEAN -only-numeric -exclude-outliers 3 3
 
-		# Convert all parcellated outputs to TSV for visualizations
-        wb_command -cifti-convert -to-text \
-            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.pscalar.nii" \
-            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.tsv"
+                # Parcellate targets using legacy mode
+                wb_command -cifti-parcellate \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+                    "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
+                    -method MEAN -only-numeric -legacy-mode
 
-		wb_command -cifti-convert -to-text \
-            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
-            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.tsv"
+                wb_command -cifti-parcellate \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+                    "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
+                    -method MEAN -only-numeric -legacy-mode
 
-		wb_command -cifti-convert -to-text \
-            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
-            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.tsv"
-		
-		# Mask vertex-wise results for visualizations in supplementary information
-	    wb_command -cifti-restrict-dense-map "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_masked.dscalar.nii" \
-	    	-left-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_left_hemi.shape.gii" \
-	    	-right-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_right_hemi.shape.gii";
-		
-	    # Same step as previous with Fisher-z outputs
-	    wb_command -cifti-restrict-dense-map "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" COLUMN \
-	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_masked.dscalar.nii" \
-	    	-left-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_left_hemi.shape.gii" \
-	    	-right-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_right_hemi.shape.gii";
+                # Convert all parcellated outputs to TSV for visualizations
+                wb_command -cifti-convert -to-text \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.pscalar.nii" \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.tsv"
 
-		# Remove files that occupy excessive memory space
-        rm "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii"
-        rm "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii"
-		
-	  done
-	done
+                wb_command -cifti-convert -to-text \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.tsv"
 
-# Grant permissions to output files
-chmod -Rf 771 "$OUT_DIR"
-chgrp -Rf 327 "$OUT_DIR"
+                wb_command -cifti-convert -to-text \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.tsv"
+
+                # Mask vertex-wise results for supplementary visualizations
+                wb_command -cifti-restrict-dense-map \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_masked.dscalar.nii" \
+                    -left-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_left_hemi.shape.gii" \
+                    -right-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_right_hemi.shape.gii"
+
+                # Same step for Fisher-z outputs
+                wb_command -cifti-restrict-dense-map \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" COLUMN \
+                    "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_masked.dscalar.nii" \
+                    -left-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_left_hemi.shape.gii" \
+                    -right-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_right_hemi.shape.gii"
+
+                # Remove files that occupy excessive memory space
+                rm "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii"
+                rm "$OUT_DIR/sub-${i}_task-rest${RUN_TAG}_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii"
+
+            done
+        done
+    done
+
+    # Grant permissions to output files
+    chmod -Rf 771 "$OUT_DIR"
+    chgrp -Rf 327 "$OUT_DIR"
 
 done

--- a/RetinoMaps/rest/correlations/legacy_scripts/connectome-workbench_dense_full_corr_by_hemi.sh
+++ b/RetinoMaps/rest/correlations/legacy_scripts/connectome-workbench_dense_full_corr_by_hemi.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+#####################################################
+# Goal of the script:
+# Compute full correlation by vertex intra-hemispherically using Connectome Workbench v. 2.1
+# Outputs are parcellated using the mean method and masked for supplementary info visualizations
+# 
+# Written by Marco Bedini (marco.bedini@univ-amu.fr)
+#####################################################
+
+# Define some paths
+TASK_RESULTS="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
+ATLAS="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
+
+# Iterate through subjects
+for i in 01 02 03 04 05 06 07 08 09 11 12 13 14 17 20 21 22 23 24 25;
+do
+
+SEED_DIR="$TASK_RESULTS/sub-${i}/91k/rest/seed"
+OUT_DIR="$TASK_RESULTS/sub-${i}/91k/rest/corr/full_corr/workbench_full_corr/by_hemi"
+
+## Make sure all files are accessible
+chmod -Rf 771 "$SEED_DIR"
+chgrp -Rf 327 "$SEED_DIR"
+
+mkdir -p "$OUT_DIR"
+
+	for ROI in mPCS sPCS iPCS sIPS iIPS hMT+ VO LO V3AB V3 V2 V1;
+	do
+	  for HEMI in lh rh;
+
+	  # For run in 01 02 []
+	  do
+
+	    if [ "$HEMI" = "lh" ]; then
+	      ROI_FLAG="-left-roi"
+	    else
+	      ROI_FLAG="-right-roi"
+	    fi
+
+	    ROI_FILE="$SEED_DIR/sub-${i}_91k_intertask_Sac-Pur-pRF_${HEMI}_${ROI}.shape.gii"
+
+	    # Full correlation
+	    wb_command -cifti-correlation \
+	    	"$TASK_RESULTS/sub-${i}/91k/rest/timeseries/sub-${i}_ses-01_task-rest_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii" \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii" \
+	    	-roi-override $ROI_FLAG "$ROI_FILE" \
+	    	-mem-limit 20
+
+	    # Fisher-z
+	    wb_command -cifti-correlation \
+	    	"$TASK_RESULTS/sub-${i}/91k/rest/timeseries/sub-${i}_ses-01_task-rest_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii" \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii" \
+	    	-roi-override $ROI_FLAG "$ROI_FILE" \
+	    	-fisher-z -mem-limit 20
+
+	    # Average within seed ROI
+	    wb_command -cifti-average-dense-roi \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+	    	$ROI_FLAG "$ROI_FILE" \
+	    	-cifti "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii"
+
+	    wb_command -cifti-average-dense-roi \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+	    	$ROI_FLAG "$ROI_FILE" \
+	    	-cifti "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii"
+
+	    # Parcellate targets
+	    wb_command -cifti-parcellate \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated.pscalar.nii" \
+	    	-method MEAN -only-numeric;
+
+	    wb_command -cifti-parcellate \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.pscalar.nii" \
+	    	-method MEAN -only-numeric;
+
+	    # Parcellate excluding outliers
+	    wb_command -cifti-parcellate \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
+	    	-method MEAN -only-numeric -exclude-outliers 3 3;
+
+	    wb_command -cifti-parcellate \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
+	    	-method MEAN -only-numeric -exclude-outliers 3 3;
+
+		# Parcellate targets using -legacy-mode (just to check if different behavior on sub-25 mPCS)
+	    wb_command -cifti-parcellate \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" \
+	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
+	    	-method MEAN -only-numeric -legacy-mode;
+
+	    wb_command -cifti-parcellate \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" \
+	    	"$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_dseg.dlabel.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
+	    	-method MEAN -only-numeric -legacy-mode;
+
+		# Convert all parcellated outputs to TSV for visualizations
+        wb_command -cifti-convert -to-text \
+            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.pscalar.nii" \
+            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated.tsv"
+
+		wb_command -cifti-convert -to-text \
+            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.pscalar.nii" \
+            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_legacy-mode.tsv"
+
+		wb_command -cifti-convert -to-text \
+            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.pscalar.nii" \
+            "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_parcellated_no_outliers.tsv"
+		
+		# Mask vertex-wise results for visualizations in supplementary information
+	    wb_command -cifti-restrict-dense-map "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dscalar.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}_masked.dscalar.nii" \
+	    	-left-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_left_hemi.shape.gii" \
+	    	-right-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_right_hemi.shape.gii";
+		
+	    # Same step as previous with Fisher-z outputs
+	    wb_command -cifti-restrict-dense-map "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dscalar.nii" COLUMN \
+	    	"$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}_masked.dscalar.nii" \
+	    	-left-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_left_hemi.shape.gii" \
+	    	-right-roi "$ATLAS/atlas-Glasser_space-fsLR_den-32k_filtered_ROIs_right_hemi.shape.gii";
+
+		# Remove files that occupy excessive memory space
+        rm "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-full_corr_${HEMI}_${ROI}.dconn.nii"
+        rm "$OUT_DIR/sub-${i}_task-rest_space-fsLR_den-91k_desc-fisher-z_${HEMI}_${ROI}.dconn.nii"
+		
+	  done
+	done
+
+# Grant permissions to output files
+chmod -Rf 771 "$OUT_DIR"
+chgrp -Rf 327 "$OUT_DIR"
+
+done

--- a/RetinoMaps/rest/correlations/legacy_scripts/nilearn_partial_corr_cluster-task_by_mmp-parcel_by_hemi.py
+++ b/RetinoMaps/rest/correlations/legacy_scripts/nilearn_partial_corr_cluster-task_by_mmp-parcel_by_hemi.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Mar 27, 2026
+Compute INTRA-HEMISPHERIC PARTIAL correlations between clusters (seeds)
+and parcels (targets) using Nilearn partial correlation.
 
-Compute INTRA-HEMISPHERIC* PARTIAL correlations between clusters (seeds)
-and parcels (targets) using Nilearn partial correlation
+Left-hemisphere seeds are correlated only with left-hemisphere parcels,
+and right-hemisphere seeds with right-hemisphere parcels.
 
-* i.e., Left-hemisphere seeds are correlated only with left-hemisphere parcels,
-and right-hemisphere seeds with right-hemisphere parcels
+Important note: the conditioning set now includes all other parcels
+Whether intra or inter-hemispheric 
+Matching Dawson et al. (2016) and Genç et al. (2016) 
 
 For each cluster:
   - parcels belonging to that cluster are EXCLUDED from the conditioning set
   - output shape per hemisphere = (n_clusters, n_parcels)
-
-In this version of the script we were only regressing out external parcel within hemisphere
-Somewhat in contrast with Dawson et al. (2016) and Genç et al. (2016) 
-We want to remove also inter hemispheric biases on FC however so check the newest version
 
 ---------------------------------------------------
 Written by Marco Bedini (marco.bedini@univ-amu.fr)
@@ -38,7 +36,8 @@ main_data        = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
 seed_folder      = main_data
 atlas_folder     = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
 partial_output_folder = (
-    "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/group/91k/rest/partial_corr/by_hemi"
+    "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
+    "/group/91k/rest/partial_corr/by_hemi"
 )
 os.makedirs(partial_output_folder, exist_ok=True)
 
@@ -48,6 +47,64 @@ sys.path.append(os.path.abspath(os.path.join(base_dir, "analysis_code/utils")))
 from settings_utils import load_settings
 from surface_utils import load_surface
 from cifti_utils import from_91k_to_32k
+
+# ============================================================
+# Helpers
+# ============================================================
+
+def impute_nan_columns(X: np.ndarray, label: str = "") -> np.ndarray:
+    """Replace NaN values in a (n_time × n_signals) matrix before passing to
+    Nilearn's ConnectivityMeasure, which cannot handle NaNs.
+
+    Strategy (column-wise, conservative):
+      - Columns that are entirely NaN → replaced with zeros.
+        These carry no information; zeroing them is equivalent to
+        excluding them from the partial correlation without altering
+        the matrix shape or index mapping.
+      - Columns with *some* NaN timepoints → replaced with the column mean.
+        This minimises distortion of the covariance structure relative to
+        alternatives such as linear interpolation or global-mean imputation.
+
+    A warning is printed for every affected column so the operator can
+    identify problematic parcels/seeds in the log.
+
+    Parameters
+    ----------
+    X     : array, shape (n_time, n_signals)
+    label : optional string prefix for warning messages (e.g. subject + hemi)
+
+    Returns
+    -------
+    X_clean : array, same shape, no NaNs
+    """
+    X_clean   = X.copy()
+    n_signals = X_clean.shape[1]
+
+    for j in range(n_signals):
+        col      = X_clean[:, j]
+        nan_mask = np.isnan(col)
+
+        if not nan_mask.any():
+            continue
+
+        n_nan = int(nan_mask.sum())
+
+        if nan_mask.all():
+            print(
+                f"  {'[' + label + '] ' if label else ''}⚠️  Column {j}: "
+                f"ALL {n_nan} timepoints are NaN — replacing with zeros"
+            )
+            X_clean[:, j] = 0.0
+        else:
+            col_mean = np.nanmean(col)
+            print(
+                f"  {'[' + label + '] ' if label else ''}⚠️  Column {j}: "
+                f"{n_nan}/{len(col)} NaN timepoints — imputing with column mean "
+                f"({col_mean:.4f})"
+            )
+            X_clean[nan_mask, j] = col_mean
+
+    return X_clean
 
 # Load settings
 project_dir = "RetinoMaps"
@@ -77,8 +134,8 @@ for cl in clusters:
 # Each entry drives the full pipeline for one hemisphere:
 #   seed_key  : suffix used in seed .shape.gii filenames  (lh / rh)
 #   atlas_key : prefix used in atlas parcel filenames     (L  / R )
-#   ts_key    : key returned by from_91k_to_32k for the
-#               hemisphere-specific timeseries array
+#   ts_key    : key in from_91k_to_32k result dict when
+#               return_concat_hemis=False ('data_L' / 'data_R')
 # ============================================================
 
 HEMIS = [
@@ -108,16 +165,24 @@ for subject in subjects:
 
     ts_img, ts_data_raw = load_surface(timeseries_fn)
 
-    # Request separate hemisphere arrays from the utils
-    res = from_91k_to_32k(ts_img, ts_data_raw, return_concat_hemis=False, return_32k_mask=True) # sanity check for medial wall vertices
+    # return_concat_hemis=False → separate 'data_L' and 'data_R' arrays
+    # return_32k_mask=True      → 'mask_32k' boolean array (True=cortex, False=medial wall)
+    res = from_91k_to_32k(
+        ts_img, ts_data_raw,
+        return_concat_hemis=False,
+        return_32k_mask=True,
+    )
+
+    mask_32k = res["mask_32k"]
+    print(f"  mask_32k: {int(np.sum(~mask_32k))} medial-wall vertices masked per hemi")
 
     for h in HEMIS:
-        label     = h["label"]          # "LH" or "RH"
-        seed_key  = h["seed_key"]       # "lh" or "rh"
-        atlas_key = h["atlas_key"]      # "L"  or "R"
-        ts_key    = h["ts_key"]         # "data_L" or "data_R"
+        label     = h["label"]     # "LH" or "RH"
+        seed_key  = h["seed_key"]  # "lh" or "rh"
+        atlas_key = h["atlas_key"] # "L"  or "R"
+        ts_key    = h["ts_key"]    # "data_L" or "data_R"
 
-        ts_data = res[ts_key]           # shape: (n_time, n_vertices_hemi)
+        ts_data = res[ts_key]      # shape: (n_time, n_vertices_hemi)
 
         print(f"\n  [{label}] Timeseries shape: {ts_data.shape}")
 
@@ -136,68 +201,152 @@ for subject in subjects:
             )
             mask = mask_data.ravel()
 
+            if not np.any(mask):
+                print(f"  [{label}] ⚠️  Empty seed mask for {roi} — skipping")
+                continue
+
             cluster_ts_list.append(ts_data[:, mask > 0].mean(axis=1))
             cluster_names_used.append(roi)
+
+        if not cluster_ts_list:
+            print(f"  [{label}] ⚠️  No valid cluster timeseries — skipping hemisphere")
+            continue
 
         cluster_ts = np.column_stack(cluster_ts_list)
         print(f"  [{label}] Clusters used: {cluster_names_used}")
 
         # -------------------------
-        # Parcel timeseries (single hemisphere)
+        # Parcel timeseries — BILATERAL conditioning set
+        #
+        # All 106 parcels (both hemispheres) are loaded into the conditioning
+        # matrix X so that inter-hemispheric confounds are fully controlled.
+        # We track two index sets per parcel name:
+        #   bilateral_col_idx : column position in the full 106-parcel matrix
+        #   ipsi_col_idx      : subset of the above that belongs to the
+        #                       ipsilateral hemisphere (atlas_key), used to
+        #                       read off the result values after partial corr.
         # -------------------------
 
-        parcel_ts_list   = []
-        parcel_names_used = []
+        # Both hemisphere keys, ipsilateral first so the loop is explicit
+        ATLAS_KEYS_BILATERAL = {"L": ["L", "R"], "R": ["R", "L"]}
+        atlas_keys_ordered   = ATLAS_KEYS_BILATERAL[atlas_key]   # ipsi, contra
 
-        for parcel in parcels:
-            mask_img, mask_data = load_surface(
-                f"{atlas_folder}/mmp1_clusters/parcels/"
-                f"{atlas_key}_{parcel}_ROI.shape.gii"
-            )
-            mask = mask_data.ravel()
+        parcel_ts_list    = []   # one entry per successfully loaded parcel×hemi
+        parcel_names_used = []   # matching parcel name (same parcel can appear twice)
+        parcel_hemi_used  = []   # "L" or "R" for each column
+        ipsi_col_idx      = []   # column indices that are ipsilateral
 
-            parcel_ts_list.append(ts_data[:, mask > 0].mean(axis=1))
-            parcel_names_used.append(parcel)
+        for ak in atlas_keys_ordered:
+            ts_source = res["data_L" if ak == "L" else "data_R"]
+
+            for parcel in parcels:
+                mask_img, mask_data = load_surface(
+                    f"{atlas_folder}/parcels/"
+                    f"{ak}_{parcel}_ROI.shape.gii"
+                )
+                mask = mask_data.ravel()
+
+                if not np.any(mask):
+                    continue
+
+                col_idx = len(parcel_ts_list)
+                parcel_ts_list.append(ts_source[:, mask > 0].mean(axis=1))
+                parcel_names_used.append(parcel)
+                parcel_hemi_used.append(ak)
+
+                if ak == atlas_key:
+                    ipsi_col_idx.append(col_idx)
+
+        if not parcel_ts_list:
+            print(f"  [{label}] ⚠️  No valid parcel timeseries — skipping hemisphere")
+            continue
 
         parcel_ts = np.column_stack(parcel_ts_list)
-        print(f"  [{label}] Parcels used: {len(parcel_names_used)}/{len(parcels)}")
+
+        n_ipsi   = sum(1 for h in parcel_hemi_used if h == atlas_key)
+        n_contra = sum(1 for h in parcel_hemi_used if h != atlas_key)
+        print(
+            f"  [{label}] Loaded bilateral parcel matrix: "
+            f"{parcel_ts.shape[1]} columns before exclusions "
+            f"({n_ipsi} ipsi [{atlas_key}] + {n_contra} contra)"
+        )
+
+        # Impute NaNs in both timeseries matrices before entering Nilearn.
+        # Cluster seeds are unlikely to have NaNs but checked defensively.
+        cluster_ts = impute_nan_columns(cluster_ts, label=f"{subject} {label} seed")
+        parcel_ts  = impute_nan_columns(parcel_ts,  label=f"{subject} {label} parcel")
 
         # -------------------------
         # Partial correlation
+        #
+        # Conditioning set per seed = all bilateral parcel columns MINUS:
+        #   (a) the seed's own cluster parcels (ipsilateral only, by convention)
+        #   (b) the target parcel being correlated (ipsilateral only)
+        # Result values are read from the ipsilateral columns only.
         # -------------------------
 
         n_clusters_used = cluster_ts.shape[1]
-        n_parcels_used  = parcel_ts.shape[1]
-
-        partial_matrix    = np.full((n_clusters_used, n_parcels_used), np.nan)
+        # Output matrix rows = clusters, cols = ipsilateral parcels only
+        partial_matrix    = np.full((n_clusters_used, len(ipsi_col_idx)), np.nan)
         partial_matrix_fz = np.full_like(partial_matrix, np.nan)
+
+        # Build a name→column lookup restricted to ipsilateral parcels
+        ipsi_parcel_names = [parcel_names_used[j] for j in ipsi_col_idx]
 
         for i_cl, cl_name in enumerate(cluster_names_used):
 
-            exclude = set(seed_to_parcels.get(cl_name, []))
+            # (a) seed's own cluster parcels excluded from conditioning (ipsi only)
+            seed_own_parcels = set(seed_to_parcels.get(cl_name, []))
 
-            included_idx = [
-                j for j, p in enumerate(parcel_names_used)
-                if p not in exclude
-            ]
+            for i_target, target_parcel in enumerate(ipsi_parcel_names):
 
-            X = np.column_stack([
-                cluster_ts[:, i_cl],
-                parcel_ts[:, included_idx],
-            ])
+                # (b) exclude the target parcel itself from the conditioning set
+                exclude_cols = set()
+                for j, (pname, phemi) in enumerate(
+                    zip(parcel_names_used, parcel_hemi_used)
+                ):
+                    if phemi == atlas_key and (
+                        pname in seed_own_parcels or pname == target_parcel
+                    ):
+                        exclude_cols.add(j)
 
-            conn = ConnectivityMeasure(kind="partial correlation")
-            C    = conn.fit_transform([X])[0]
+                conditioning_idx = [
+                    j for j in range(len(parcel_names_used))
+                    if j not in exclude_cols
+                    and j != ipsi_col_idx[i_target]   # target itself not in X
+                ]
 
-            vals = C[0, 1:]   # seed row, skip self-correlation
+                if not conditioning_idx:
+                    print(
+                        f"  [{label}] ⚠️  No conditioning parcels left "
+                        f"for seed {cl_name} → target {target_parcel}"
+                    )
+                    continue
 
-            partial_matrix[i_cl, included_idx]    = vals
+                # X = [seed | target_parcel | conditioning parcels]
+                # C[0,1] gives the seed ↔ target partial correlation
+                X = np.column_stack([
+                    cluster_ts[:, i_cl],
+                    parcel_ts[:, ipsi_col_idx[i_target]],
+                    parcel_ts[:, conditioning_idx],
+                ])
 
-            # Get the fizher-z transformed values
-            partial_matrix_fz[i_cl, included_idx] = np.arctanh(vals)
+                conn = ConnectivityMeasure(kind="partial correlation")
+                C    = conn.fit_transform([X])[0]
+
+                val = C[0, 1]   # seed ↔ target, conditioned on everything else
+
+                partial_matrix[i_cl, i_target]    = val
+                partial_matrix_fz[i_cl, i_target] = np.arctanh(val)
+
+        print(
+            f"  [{label}] Partial corr matrix: "
+            f"{partial_matrix.shape[0]} clusters × {partial_matrix.shape[1]} ipsi parcels"
+        )
 
         # -------------------------
         # Map back to full (clusters × parcels) grid
+        # columns correspond to the ipsilateral parcels only
         # -------------------------
 
         filled    = np.full((len(clusters), len(parcels)), np.nan)
@@ -205,10 +354,10 @@ for subject in subjects:
 
         for i_cl, cl in enumerate(cluster_names_used):
             gr = clusters.index(cl)
-            for j_pa, pa in enumerate(parcel_names_used):
+            for i_target, pa in enumerate(ipsi_parcel_names):
                 gc = parcels.index(pa)
-                filled[gr, gc]    = partial_matrix[i_cl, j_pa]
-                filled_fz[gr, gc] = partial_matrix_fz[i_cl, j_pa]
+                filled[gr, gc]    = partial_matrix[i_cl, i_target]
+                filled_fz[gr, gc] = partial_matrix_fz[i_cl, i_target]
 
         # -------------------------
         # Save subject-level results
@@ -239,7 +388,7 @@ for subject in subjects:
         all_subject_partial_fz[label].append(filled_fz)
 
 # =========================
-# GROUP STATS (per hemisphere)
+# GROUP STATS  (per hemisphere)
 # =========================
 
 print("\n=== GROUP STATS ===")
@@ -249,6 +398,10 @@ for h in HEMIS:
 
     sub_list    = all_subject_partial[label]
     sub_list_fz = all_subject_partial_fz[label]
+
+    if not sub_list:
+        print(f"  [{label}] ⚠️  No subject data collected — skipping group stats")
+        continue
 
     stacked    = np.stack(sub_list,    axis=0)   # (n_subjects, n_clusters, n_parcels)
     stacked_fz = np.stack(sub_list_fz, axis=0)
@@ -262,15 +415,15 @@ for h in HEMIS:
 
     pd.DataFrame(mean_partial,   index=clusters, columns=parcels).to_csv(
         os.path.join(partial_output_folder,
-                     f"group_mean_cluster_by_mmp-parcel_partial_{tag}_by_hemi.csv")
+                     f"group_mean_cluster_by_mmp-parcel_partial_{tag}.csv")
     )
     pd.DataFrame(median_partial, index=clusters, columns=parcels).to_csv(
         os.path.join(partial_output_folder,
-                     f"group_median_cluster_by_mmp-parcel_partial_{tag}_by_hemi.csv")
+                     f"group_median_cluster_by_mmp-parcel_partial_{tag}.csv")
     )
 
     np.savez_compressed(
-        os.path.join(partial_output_folder, f"group_partial_corr_{tag}_by_hemi.npz"),
+        os.path.join(partial_output_folder, f"group_partial_corr_{tag}.npz"),
         mean_cluster_parcel_partial         = mean_partial,
         mean_cluster_parcel_partial_fisherz = mean_partial_fz,
         median_cluster_parcel_partial       = median_partial,

--- a/RetinoMaps/rest/correlations/nilearn_partial_corr_cluster-task_by_mmp-parcel_by_hemi.py
+++ b/RetinoMaps/rest/correlations/nilearn_partial_corr_cluster-task_by_mmp-parcel_by_hemi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
+
 Compute INTRA-HEMISPHERIC PARTIAL correlations between clusters (seeds)
 and parcels (targets) using Nilearn partial correlation.
 
@@ -14,6 +15,9 @@ Matching Dawson et al. (2016) and Genç et al. (2016)
 For each cluster:
   - parcels belonging to that cluster are EXCLUDED from the conditioning set
   - output shape per hemisphere = (n_clusters, n_parcels)
+
+Outputs are also computed by run so we can exclude some based on the quality check info
+(Either eye tracking data or denoising or preproc bugs)
 
 ---------------------------------------------------
 Written by Marco Bedini (marco.bedini@univ-amu.fr)
@@ -32,9 +36,9 @@ from nilearn.connectome import ConnectivityMeasure
 # ============================================================
 USER = os.environ["USER"]
 
-main_data        = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
-seed_folder      = main_data
-atlas_folder     = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
+main_data = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
+seed_folder = main_data
+atlas_folder = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
 partial_output_folder = (
     "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
     "/group/91k/rest/partial_corr/by_hemi"
@@ -55,33 +59,12 @@ from cifti_utils import from_91k_to_32k
 def impute_nan_columns(X: np.ndarray, label: str = "") -> np.ndarray:
     """Replace NaN values in a (n_time × n_signals) matrix before passing to
     Nilearn's ConnectivityMeasure, which cannot handle NaNs.
-
-    Strategy (column-wise, conservative):
-      - Columns that are entirely NaN → replaced with zeros.
-        These carry no information; zeroing them is equivalent to
-        excluding them from the partial correlation without altering
-        the matrix shape or index mapping.
-      - Columns with *some* NaN timepoints → replaced with the column mean.
-        This minimises distortion of the covariance structure relative to
-        alternatives such as linear interpolation or global-mean imputation.
-
-    A warning is printed for every affected column so the operator can
-    identify problematic parcels/seeds in the log.
-
-    Parameters
-    ----------
-    X     : array, shape (n_time, n_signals)
-    label : optional string prefix for warning messages (e.g. subject + hemi)
-
-    Returns
-    -------
-    X_clean : array, same shape, no NaNs
     """
-    X_clean   = X.copy()
+    X_clean = X.copy()
     n_signals = X_clean.shape[1]
 
     for j in range(n_signals):
-        col      = X_clean[:, j]
+        col = X_clean[:, j]
         nan_mask = np.isnan(col)
 
         if not nan_mask.any():
@@ -106,13 +89,14 @@ def impute_nan_columns(X: np.ndarray, label: str = "") -> np.ndarray:
 
     return X_clean
 
+
 # Load settings
 project_dir = "RetinoMaps"
-settings_path     = os.path.join(base_dir, project_dir, "settings.yml")
+settings_path = os.path.join(base_dir, project_dir, "settings.yml")
 prf_settings_path = os.path.join(base_dir, project_dir, "prf-analysis.yml")
-settings          = load_settings([settings_path, prf_settings_path])
-analysis_info     = settings[0]
-subjects          = analysis_info["subjects"]
+settings = load_settings([settings_path, prf_settings_path])
+analysis_info = settings[0]
+subjects = analysis_info["subjects"]
 
 # ============================================================
 # ROIs
@@ -130,12 +114,6 @@ for cl in clusters:
 
 # ============================================================
 # Hemisphere configuration
-#
-# Each entry drives the full pipeline for one hemisphere:
-#   seed_key  : suffix used in seed .shape.gii filenames  (lh / rh)
-#   atlas_key : prefix used in atlas parcel filenames     (L  / R )
-#   ts_key    : key in from_91k_to_32k result dict when
-#               return_concat_hemis=False ('data_L' / 'data_R')
 # ============================================================
 
 HEMIS = [
@@ -143,12 +121,25 @@ HEMIS = [
     {"label": "RH", "seed_key": "rh", "atlas_key": "R", "ts_key": "data_R"},
 ]
 
+# ============================================================
+# Runs
+# ============================================================
+
+RUNS = ["run-01", "run-02", ""]
+
 # =========================
-# STORAGE  (keyed by hemi label)
+# STORAGE (run × hemisphere)
 # =========================
 
-all_subject_partial    = {h["label"]: [] for h in HEMIS}
-all_subject_partial_fz = {h["label"]: [] for h in HEMIS}
+all_subject_partial = {
+    run: {h["label"]: [] for h in HEMIS}
+    for run in RUNS
+}
+
+all_subject_partial_fz = {
+    run: {h["label"]: [] for h in HEMIS}
+    for run in RUNS
+}
 
 # =========================
 # SUBJECT LOOP
@@ -156,285 +147,259 @@ all_subject_partial_fz = {h["label"]: [] for h in HEMIS}
 
 for subject in subjects:
 
-    print(f"\n=== Processing {subject} ===")
+    for run in RUNS:
 
-    timeseries_fn = (
-        f"{main_data}/{subject}/91k/rest/timeseries/"
-        f"{subject}_ses-01_task-rest_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii"
-    )
+        run_tag = f"_{run}" if run else ""
 
-    ts_img, ts_data_raw = load_surface(timeseries_fn)
+        print(f"\n=== Processing {subject}{run_tag} ===")
 
-    # return_concat_hemis=False → separate 'data_L' and 'data_R' arrays
-    # return_32k_mask=True      → 'mask_32k' boolean array (True=cortex, False=medial wall)
-    res = from_91k_to_32k(
-        ts_img, ts_data_raw,
-        return_concat_hemis=False,
-        return_32k_mask=True,
-    )
+        timeseries_fn = (
+            f"{main_data}/{subject}/91k/rest/timeseries/"
+            f"{subject}_ses-01_task-rest{run_tag}_space-fsLR_den-91k_desc-denoised_bold.dtseries.nii"
+        )
 
-    mask_32k = res["mask_32k"]
-    print(f"  mask_32k: {int(np.sum(~mask_32k))} medial-wall vertices masked per hemi")
+        ts_img, ts_data_raw = load_surface(timeseries_fn)
 
-    for h in HEMIS:
-        label     = h["label"]     # "LH" or "RH"
-        seed_key  = h["seed_key"]  # "lh" or "rh"
-        atlas_key = h["atlas_key"] # "L"  or "R"
-        ts_key    = h["ts_key"]    # "data_L" or "data_R"
+        res = from_91k_to_32k(
+            ts_img,
+            ts_data_raw,
+            return_concat_hemis=False,
+            return_32k_mask=True,
+        )
 
-        ts_data = res[ts_key]      # shape: (n_time, n_vertices_hemi)
+        mask_32k = res["mask_32k"]
+        print(
+            f"  mask_32k: {int(np.sum(~mask_32k))} medial-wall vertices masked per hemi"
+        )
 
-        print(f"\n  [{label}] Timeseries shape: {ts_data.shape}")
+        for h in HEMIS:
+            label = h["label"]
+            seed_key = h["seed_key"]
+            atlas_key = h["atlas_key"]
+            ts_key = h["ts_key"]
 
-        # -------------------------
-        # Cluster timeseries (single hemisphere)
-        # -------------------------
+            ts_data = res[ts_key]
 
-        cluster_ts_list   = []
-        cluster_names_used = []
+            print(f"\n  [{label}] Timeseries shape: {ts_data.shape}")
 
-        for roi in clusters:
-            mask_img, mask_data = load_surface(
-                f"{main_data}/{subject}/91k/rest/seed/"
-                f"{subject}_91k_intertask_Sac-Pur-pRF"
-                f"_{seed_key}_{roi}.shape.gii"
-            )
-            mask = mask_data.ravel()
+            # -------------------------
+            # Cluster timeseries
+            # -------------------------
 
-            if not np.any(mask):
-                print(f"  [{label}] ⚠️  Empty seed mask for {roi} — skipping")
-                continue
+            cluster_ts_list = []
+            cluster_names_used = []
 
-            cluster_ts_list.append(ts_data[:, mask > 0].mean(axis=1))
-            cluster_names_used.append(roi)
-
-        if not cluster_ts_list:
-            print(f"  [{label}] ⚠️  No valid cluster timeseries — skipping hemisphere")
-            continue
-
-        cluster_ts = np.column_stack(cluster_ts_list)
-        print(f"  [{label}] Clusters used: {cluster_names_used}")
-
-        # -------------------------
-        # Parcel timeseries — BILATERAL conditioning set
-        #
-        # All 106 parcels (both hemispheres) are loaded into the conditioning
-        # matrix X so that inter-hemispheric confounds are fully controlled.
-        # We track two index sets per parcel name:
-        #   bilateral_col_idx : column position in the full 106-parcel matrix
-        #   ipsi_col_idx      : subset of the above that belongs to the
-        #                       ipsilateral hemisphere (atlas_key), used to
-        #                       read off the result values after partial corr.
-        # -------------------------
-
-        # Both hemisphere keys, ipsilateral first so the loop is explicit
-        ATLAS_KEYS_BILATERAL = {"L": ["L", "R"], "R": ["R", "L"]}
-        atlas_keys_ordered   = ATLAS_KEYS_BILATERAL[atlas_key]   # ipsi, contra
-
-        parcel_ts_list    = []   # one entry per successfully loaded parcel×hemi
-        parcel_names_used = []   # matching parcel name (same parcel can appear twice)
-        parcel_hemi_used  = []   # "L" or "R" for each column
-        ipsi_col_idx      = []   # column indices that are ipsilateral
-
-        for ak in atlas_keys_ordered:
-            ts_source = res["data_L" if ak == "L" else "data_R"]
-
-            for parcel in parcels:
+            for roi in clusters:
                 mask_img, mask_data = load_surface(
-                    f"{atlas_folder}/parcels/"
-                    f"{ak}_{parcel}_ROI.shape.gii"
+                    f"{main_data}/{subject}/91k/rest/seed/"
+                    f"{subject}_91k_intertask_Sac-Pur-pRF"
+                    f"_{seed_key}_{roi}.shape.gii"
                 )
+
                 mask = mask_data.ravel()
 
                 if not np.any(mask):
+                    print(f"  [{label}] ⚠️  Empty seed mask for {roi} — skipping")
                     continue
 
-                col_idx = len(parcel_ts_list)
-                parcel_ts_list.append(ts_source[:, mask > 0].mean(axis=1))
-                parcel_names_used.append(parcel)
-                parcel_hemi_used.append(ak)
+                cluster_ts_list.append(ts_data[:, mask > 0].mean(axis=1))
+                cluster_names_used.append(roi)
 
-                if ak == atlas_key:
-                    ipsi_col_idx.append(col_idx)
+            if not cluster_ts_list:
+                print(
+                    f"  [{label}] ⚠️  No valid cluster timeseries — skipping hemisphere"
+                )
+                continue
 
-        if not parcel_ts_list:
-            print(f"  [{label}] ⚠️  No valid parcel timeseries — skipping hemisphere")
-            continue
+            cluster_ts = np.column_stack(cluster_ts_list)
+            print(f"  [{label}] Clusters used: {cluster_names_used}")
 
-        parcel_ts = np.column_stack(parcel_ts_list)
+            # -------------------------
+            # Parcel timeseries (bilateral conditioning)
+            # -------------------------
 
-        n_ipsi   = sum(1 for h in parcel_hemi_used if h == atlas_key)
-        n_contra = sum(1 for h in parcel_hemi_used if h != atlas_key)
-        print(
-            f"  [{label}] Loaded bilateral parcel matrix: "
-            f"{parcel_ts.shape[1]} columns before exclusions "
-            f"({n_ipsi} ipsi [{atlas_key}] + {n_contra} contra)"
-        )
+            ATLAS_KEYS_BILATERAL = {"L": ["L", "R"], "R": ["R", "L"]}
+            atlas_keys_ordered = ATLAS_KEYS_BILATERAL[atlas_key]
 
-        # Impute NaNs in both timeseries matrices before entering Nilearn.
-        # Cluster seeds are unlikely to have NaNs but checked defensively.
-        cluster_ts = impute_nan_columns(cluster_ts, label=f"{subject} {label} seed")
-        parcel_ts  = impute_nan_columns(parcel_ts,  label=f"{subject} {label} parcel")
+            parcel_ts_list = []
+            parcel_names_used = []
+            parcel_hemi_used = []
+            ipsi_col_idx = []
 
-        # -------------------------
-        # Partial correlation
-        #
-        # Conditioning set per seed = all bilateral parcel columns MINUS:
-        #   (a) the seed's own cluster parcels (ipsilateral only, by convention)
-        #   (b) the target parcel being correlated (ipsilateral only)
-        # Result values are read from the ipsilateral columns only.
-        # -------------------------
+            for ak in atlas_keys_ordered:
+                ts_source = res["data_L" if ak == "L" else "data_R"]
 
-        n_clusters_used = cluster_ts.shape[1]
-        # Output matrix rows = clusters, cols = ipsilateral parcels only
-        partial_matrix    = np.full((n_clusters_used, len(ipsi_col_idx)), np.nan)
-        partial_matrix_fz = np.full_like(partial_matrix, np.nan)
-
-        # Build a name→column lookup restricted to ipsilateral parcels
-        ipsi_parcel_names = [parcel_names_used[j] for j in ipsi_col_idx]
-
-        for i_cl, cl_name in enumerate(cluster_names_used):
-
-            # (a) seed's own cluster parcels excluded from conditioning (ipsi only)
-            seed_own_parcels = set(seed_to_parcels.get(cl_name, []))
-
-            for i_target, target_parcel in enumerate(ipsi_parcel_names):
-
-                # (b) exclude the target parcel itself from the conditioning set
-                exclude_cols = set()
-                for j, (pname, phemi) in enumerate(
-                    zip(parcel_names_used, parcel_hemi_used)
-                ):
-                    if phemi == atlas_key and (
-                        pname in seed_own_parcels or pname == target_parcel
-                    ):
-                        exclude_cols.add(j)
-
-                conditioning_idx = [
-                    j for j in range(len(parcel_names_used))
-                    if j not in exclude_cols
-                    and j != ipsi_col_idx[i_target]   # target itself not in X
-                ]
-
-                if not conditioning_idx:
-                    print(
-                        f"  [{label}] ⚠️  No conditioning parcels left "
-                        f"for seed {cl_name} → target {target_parcel}"
+                for parcel in parcels:
+                    mask_img, mask_data = load_surface(
+                        f"{atlas_folder}/parcels/{ak}_{parcel}_ROI.shape.gii"
                     )
-                    continue
 
-                # X = [seed | target_parcel | conditioning parcels]
-                # C[0,1] gives the seed ↔ target partial correlation
-                X = np.column_stack([
-                    cluster_ts[:, i_cl],
-                    parcel_ts[:, ipsi_col_idx[i_target]],
-                    parcel_ts[:, conditioning_idx],
-                ])
+                    mask = mask_data.ravel()
 
-                conn = ConnectivityMeasure(kind="partial correlation")
-                C    = conn.fit_transform([X])[0]
+                    if not np.any(mask):
+                        continue
 
-                val = C[0, 1]   # seed ↔ target, conditioned on everything else
+                    col_idx = len(parcel_ts_list)
 
-                partial_matrix[i_cl, i_target]    = val
-                partial_matrix_fz[i_cl, i_target] = np.arctanh(val)
+                    parcel_ts_list.append(ts_source[:, mask > 0].mean(axis=1))
+                    parcel_names_used.append(parcel)
+                    parcel_hemi_used.append(ak)
 
-        print(
-            f"  [{label}] Partial corr matrix: "
-            f"{partial_matrix.shape[0]} clusters × {partial_matrix.shape[1]} ipsi parcels"
-        )
+                    if ak == atlas_key:
+                        ipsi_col_idx.append(col_idx)
 
-        # -------------------------
-        # Map back to full (clusters × parcels) grid
-        # columns correspond to the ipsilateral parcels only
-        # -------------------------
+            if not parcel_ts_list:
+                print(
+                    f"  [{label}] ⚠️  No valid parcel timeseries — skipping hemisphere"
+                )
+                continue
 
-        filled    = np.full((len(clusters), len(parcels)), np.nan)
-        filled_fz = filled.copy()
+            parcel_ts = np.column_stack(parcel_ts_list)
 
-        for i_cl, cl in enumerate(cluster_names_used):
-            gr = clusters.index(cl)
-            for i_target, pa in enumerate(ipsi_parcel_names):
-                gc = parcels.index(pa)
-                filled[gr, gc]    = partial_matrix[i_cl, i_target]
-                filled_fz[gr, gc] = partial_matrix_fz[i_cl, i_target]
+            n_ipsi = sum(1 for h_ in parcel_hemi_used if h_ == atlas_key)
+            n_contra = sum(1 for h_ in parcel_hemi_used if h_ != atlas_key)
 
-        # -------------------------
-        # Save subject-level results
-        # -------------------------
+            print(
+                f"  [{label}] Loaded bilateral parcel matrix: "
+                f"{parcel_ts.shape[1]} columns before exclusions "
+                f"({n_ipsi} ipsi [{atlas_key}] + {n_contra} contra)"
+            )
 
-        sub_out = f"{main_data}/{subject}/91k/rest/corr/partial_corr/by_hemi"
-        os.makedirs(sub_out, exist_ok=True)
+            cluster_ts = impute_nan_columns(
+                cluster_ts, label=f"{subject}{run_tag} {label} seed"
+            )
+            parcel_ts = impute_nan_columns(
+                parcel_ts, label=f"{subject}{run_tag} {label} parcel"
+            )
 
-        tag = label.lower()   # "lh" or "rh"
+            # -------------------------
+            # Partial correlation
+            # -------------------------
 
-        np.save(
-            os.path.join(sub_out, f"cluster_by_mmp-parcel_partial_{tag}.npy"),
-            filled,
-        )
-        np.save(
-            os.path.join(sub_out, f"cluster_by_mmp-parcel_partial_fisherz_{tag}.npy"),
-            filled_fz,
-        )
+            n_clusters_used = cluster_ts.shape[1]
 
-        pd.DataFrame(filled,    index=clusters, columns=parcels).to_csv(
-            os.path.join(sub_out, f"cluster_by_mmp-parcel_partial_{tag}.csv")
-        )
-        pd.DataFrame(filled_fz, index=clusters, columns=parcels).to_csv(
-            os.path.join(sub_out, f"cluster_by_mmp-parcel_partial_fisherz_{tag}.csv")
-        )
+            partial_matrix = np.full(
+                (n_clusters_used, len(ipsi_col_idx)),
+                np.nan
+            )
+            partial_matrix_fz = np.full_like(partial_matrix, np.nan)
 
-        all_subject_partial[label].append(filled)
-        all_subject_partial_fz[label].append(filled_fz)
+            ipsi_parcel_names = [parcel_names_used[j] for j in ipsi_col_idx]
 
-# =========================
-# GROUP STATS  (per hemisphere)
-# =========================
+            for i_cl, cl_name in enumerate(cluster_names_used):
 
-print("\n=== GROUP STATS ===")
+                seed_own_parcels = set(seed_to_parcels.get(cl_name, []))
 
-for h in HEMIS:
-    label = h["label"]
+                for i_target, target_parcel in enumerate(ipsi_parcel_names):
 
-    sub_list    = all_subject_partial[label]
-    sub_list_fz = all_subject_partial_fz[label]
+                    exclude_cols = set()
 
-    if not sub_list:
-        print(f"  [{label}] ⚠️  No subject data collected — skipping group stats")
-        continue
+                    for j, (pname, phemi) in enumerate(
+                        zip(parcel_names_used, parcel_hemi_used)
+                    ):
+                        if phemi == atlas_key and (
+                            pname in seed_own_parcels or pname == target_parcel
+                        ):
+                            exclude_cols.add(j)
 
-    stacked    = np.stack(sub_list,    axis=0)   # (n_subjects, n_clusters, n_parcels)
-    stacked_fz = np.stack(sub_list_fz, axis=0)
+                    conditioning_idx = [
+                        j for j in range(len(parcel_names_used))
+                        if j not in exclude_cols
+                        and j != ipsi_col_idx[i_target]
+                    ]
 
-    mean_partial    = np.nanmean(stacked,    axis=0)
-    median_partial  = np.nanmedian(stacked,  axis=0)
-    mean_partial_fz = np.nanmean(stacked_fz, axis=0)
-    median_partial_fz = np.nanmedian(stacked_fz, axis=0)
+                    if not conditioning_idx:
+                        print(
+                            f"  [{label}] ⚠️  No conditioning parcels left "
+                            f"for seed {cl_name} → target {target_parcel}"
+                        )
+                        continue
 
-    tag = label.lower()
+                    X = np.column_stack([
+                        cluster_ts[:, i_cl],
+                        parcel_ts[:, ipsi_col_idx[i_target]],
+                        parcel_ts[:, conditioning_idx],
+                    ])
 
-    pd.DataFrame(mean_partial,   index=clusters, columns=parcels).to_csv(
-        os.path.join(partial_output_folder,
-                     f"group_mean_cluster_by_mmp-parcel_partial_{tag}.csv")
-    )
-    pd.DataFrame(median_partial, index=clusters, columns=parcels).to_csv(
-        os.path.join(partial_output_folder,
-                     f"group_median_cluster_by_mmp-parcel_partial_{tag}.csv")
-    )
+                    conn = ConnectivityMeasure(kind="partial correlation")
+                    C = conn.fit_transform([X])[0]
 
-    np.savez_compressed(
-        os.path.join(partial_output_folder, f"group_partial_corr_{tag}.npz"),
-        mean_cluster_parcel_partial         = mean_partial,
-        mean_cluster_parcel_partial_fisherz = mean_partial_fz,
-        median_cluster_parcel_partial       = median_partial,
-        median_cluster_parcel_partial_fisherz = median_partial_fz,
-        subjects  = np.array(subjects),
-        clusters  = np.array(clusters),
-        parcels   = np.array(parcels),
-        hemi      = np.array(label),
-    )
+                    val = C[0, 1]
 
-    print(f"  [{label}] Group stats saved.")
+                    partial_matrix[i_cl, i_target] = val
+                    partial_matrix_fz[i_cl, i_target] = np.arctanh(val)
+
+            print(
+                f"  [{label}] Partial corr matrix: "
+                f"{partial_matrix.shape[0]} clusters × "
+                f"{partial_matrix.shape[1]} ipsi parcels"
+            )
+
+            # -------------------------
+            # Map back to full grid
+            # -------------------------
+
+            filled = np.full((len(clusters), len(parcels)), np.nan)
+            filled_fz = filled.copy()
+
+            for i_cl, cl in enumerate(cluster_names_used):
+                gr = clusters.index(cl)
+
+                for i_target, pa in enumerate(ipsi_parcel_names):
+                    gc = parcels.index(pa)
+
+                    filled[gr, gc] = partial_matrix[i_cl, i_target]
+                    filled_fz[gr, gc] = partial_matrix_fz[i_cl, i_target]
+
+            # -------------------------
+            # Save subject-level results
+            # -------------------------
+
+            sub_out = f"{main_data}/{subject}/91k/rest/corr/partial_corr/by_hemi"
+            os.makedirs(sub_out, exist_ok=True)
+
+            tag = label.lower()
+
+            np.save(
+                os.path.join(
+                    sub_out,
+                    f"cluster_by_mmp-parcel_partial{run_tag}_{tag}.npy"
+                ),
+                filled,
+            )
+
+            np.save(
+                os.path.join(
+                    sub_out,
+                    f"cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.npy"
+                ),
+                filled_fz,
+            )
+
+            pd.DataFrame(
+                filled,
+                index=clusters,
+                columns=parcels
+            ).to_csv(
+                os.path.join(
+                    sub_out,
+                    f"cluster_by_mmp-parcel_partial{run_tag}_{tag}.csv"
+                )
+            )
+
+            pd.DataFrame(
+                filled_fz,
+                index=clusters,
+                columns=parcels
+            ).to_csv(
+                os.path.join(
+                    sub_out,
+                    f"cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.csv"
+                )
+            )
+
+            all_subject_partial[run][label].append(filled)
+            all_subject_partial_fz[run][label].append(filled_fz)
 
 print("\nDone.")
 # ============================================================

--- a/RetinoMaps/rest/correlations/submit_nilearn_compute_partial_corr_job.py
+++ b/RetinoMaps/rest/correlations/submit_nilearn_compute_partial_corr_job.py
@@ -53,7 +53,7 @@ else:
         f"Got: {mode}"
     )
 
-memory_val = 10 # GB
+memory_val = 50 # GB
 nb_procs = 16 # number of CPUs
 cluster_name = 'skylake'
 

--- a/RetinoMaps/rest/correlations/submit_workbench_compute_full_corr_job.py
+++ b/RetinoMaps/rest/correlations/submit_workbench_compute_full_corr_job.py
@@ -53,8 +53,8 @@ else:
         f"Got: {mode}"
     )
 
-memory_val = 20 # GB
-nb_procs = 16 # number of CPUs
+memory_val = 50 # GB
+nb_procs = 32 # number of CPUs
 cluster_name = 'skylake'
 job_suffix = "workbench"
 corr_type = "full_corr"

--- a/RetinoMaps/rest/denoising/fmripost_aroma_aggr_sbatch.py
+++ b/RetinoMaps/rest/denoising/fmripost_aroma_aggr_sbatch.py
@@ -66,7 +66,7 @@ slurm_cmd = """\
 #SBATCH -p {cluster_name}
 #SBATCH -A {server_project}
 #SBATCH --nodes=1
-#SBATCH --mem={memory_val}mb
+#SBATCH --mem={memory_val}gb
 #SBATCH --cpus-per-task={nb_procs}
 #SBATCH --time={hour_proc}:00:00
 #SBATCH -e {log_dir}/{subject}_fmripost_aroma_%N_%j_%a.err

--- a/RetinoMaps/rest/quality_check/connectome-workbench_compute_full_corr.sh
+++ b/RetinoMaps/rest/quality_check/connectome-workbench_compute_full_corr.sh
@@ -7,7 +7,7 @@
 #####################################################
 
 # Define some paths
-TASK_RESULTS="/scratch/mszinte/data/RetinoMaps/derivatives/xcp-d_w_atlas"
+TASK_RESULTS="/scratch/mszinte/data/RetinoMaps/derivatives/xcp-d"
 ATLAS="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
 OUT_DIR="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/quality_check"
 

--- a/RetinoMaps/rest/quality_check/connectome-workbench_parcellate_full_corr.sh
+++ b/RetinoMaps/rest/quality_check/connectome-workbench_parcellate_full_corr.sh
@@ -7,7 +7,7 @@
 #####################################################
 
 # Define some paths
-TASK_RESULTS="/scratch/mszinte/data/RetinoMaps/derivatives/xcp-d_w_atlas"
+TASK_RESULTS="/scratch/mszinte/data/RetinoMaps/derivatives/xcp-d"
 ATLAS="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/atlas"
 OUT_DIR="/scratch/mszinte/data/RetinoMaps/derivatives/pp_data/quality_check"
 

--- a/RetinoMaps/rest/quality_check/submit_workbench_compute_full_corr_job.py
+++ b/RetinoMaps/rest/quality_check/submit_workbench_compute_full_corr_job.py
@@ -39,7 +39,7 @@ group = sys.argv[3]
 server_project = sys.argv[4]
 proc_time = sys.argv[5] #
 
-memory_val = 50 # GB
+memory_val = 100 # GB
 nb_procs = 32 # number of CPUs
 cluster_name = 'skylake'
 job_suffix = "workbench_parcellated"

--- a/RetinoMaps/rest/quality_check/submit_workbench_parcellate_full_corr_job.py
+++ b/RetinoMaps/rest/quality_check/submit_workbench_parcellate_full_corr_job.py
@@ -39,8 +39,8 @@ group = sys.argv[3]
 server_project = sys.argv[4]
 proc_time = sys.argv[5] #
 
-memory_val = 20 # GB
-nb_procs = 16 # number of CPUs
+memory_val = 100 # GB
+nb_procs = 32 # number of CPUs
 cluster_name = 'skylake'
 job_suffix = "workbench_parcellated"
 corr_type = "full_corr"

--- a/RetinoMaps/rest/stats/group_stats_partial_corr.py
+++ b/RetinoMaps/rest/stats/group_stats_partial_corr.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Group-level statistics for intra-hemispheric partial correlations.
+
+Operates on per-subject Fisher-z matrices produced by the computation script.
+Averaging is always performed in Fisher-z space; Pearson r is recovered only
+at the final reporting stage via tanh().
+
+This separation is intentional:
+  - Fisher-z has approximately constant variance ~1/(n-3), making it the
+    correct space for averaging and any subsequent parametric tests
+  - Raw Pearson r values have r-dependent variance and should never be
+    averaged directly
+
+Outputs per hemisphere × run:
+  - group mean and median in Fisher-z space      (.npy, .csv)
+  - group mean and median back-converted to r    (.npy, .csv)
+  - compressed archive with all four arrays      (.npz)
+
+---------------------------------------------------
+Written by Marco Bedini (marco.bedini@univ-amu.fr)
+---------------------------------------------------
+"""
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+
+# ============================================================
+# Paths
+# ============================================================
+
+main_data             = "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
+partial_output_folder = (
+    "/scratch/mszinte/data/RetinoMaps/derivatives/pp_data"
+    "/group/91k/rest/partial_corr/by_hemi"
+)
+os.makedirs(partial_output_folder, exist_ok=True)
+
+# Personal imports
+base_dir = os.path.abspath(os.path.join(os.getcwd(), "../../../"))
+sys.path.append(os.path.abspath(os.path.join(base_dir, "analysis_code/utils")))
+from settings_utils import load_settings
+
+# ============================================================
+# Settings
+# ============================================================
+
+project_dir       = "RetinoMaps"
+settings_path     = os.path.join(base_dir, project_dir, "settings.yml")
+prf_settings_path = os.path.join(base_dir, project_dir, "prf-analysis.yml")
+settings          = load_settings([settings_path, prf_settings_path])
+analysis_info     = settings[0]
+subjects          = analysis_info["subjects"]
+
+# ============================================================
+# ROIs — needed for DataFrame index/columns and .npz metadata
+# ============================================================
+
+clusters = analysis_info["rois-drawn"]
+seed_to_parcels = analysis_info["rois-group-mmp"]
+
+clusters.reverse()   # mPCS first
+
+parcels = []
+for cl in clusters:
+    parcels.extend(seed_to_parcels[cl])
+
+# ============================================================
+# Configuration
+# ============================================================
+
+HEMIS = [
+    {"label": "LH", "tag": "lh"},
+    {"label": "RH", "tag": "rh"},
+]
+
+RUNS = ["run-01", "run-02", ""]   # "" = full concatenated session
+
+# ============================================================
+# GROUP STATS
+# ============================================================
+
+print("=== GROUP STATS ===\n")
+
+for run in RUNS:
+
+    run_tag = f"_{run}" if run else ""
+
+    for h in HEMIS:
+        label = h["label"]
+        tag   = h["tag"]
+
+        # -------------------------
+        # Load per-subject Fisher-z matrices
+        # -------------------------
+
+        fz_stack = []
+        missing  = []
+
+        for subject in subjects:
+            sub_path = os.path.join(
+                main_data, subject,
+                "91k/rest/corr/partial_corr/by_hemi",
+                f"cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.npy"
+            )
+
+            if not os.path.isfile(sub_path):
+                print(f"  [{label}{run_tag}] ⚠️  Missing: {subject} — skipped")
+                missing.append(subject)
+                continue
+
+            fz_stack.append(np.load(sub_path))
+
+        if not fz_stack:
+            print(
+                f"  [{label}{run_tag}] ⚠️  No subject files found — "
+                "skipping group stats"
+            )
+            continue
+
+        n_loaded = len(fz_stack)
+        n_total  = len(subjects)
+        print(
+            f"  [{label}{run_tag}] Loaded {n_loaded}/{n_total} subjects"
+            + (f" (missing: {missing})" if missing else "")
+        )
+
+        stacked_fz = np.stack(fz_stack, axis=0)   # (n_subjects, n_clusters, n_parcels)
+
+        # -------------------------
+        # Aggregate in Fisher-z space
+        # -------------------------
+
+        mean_fz   = np.nanmean(stacked_fz,   axis=0)
+        median_fz = np.nanmedian(stacked_fz, axis=0)
+
+        # -------------------------
+        # Convert to Pearson r only at reporting stage
+        # -------------------------
+
+        mean_r   = np.tanh(mean_fz)
+        median_r = np.tanh(median_fz)
+
+        # -------------------------
+        # Save
+        # -------------------------
+
+        # Fisher-z arrays
+        np.save(
+            os.path.join(
+                partial_output_folder,
+                f"group_mean_cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.npy"
+            ),
+            mean_fz,
+        )
+        np.save(
+            os.path.join(
+                partial_output_folder,
+                f"group_median_cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.npy"
+            ),
+            median_fz,
+        )
+
+        pd.DataFrame(mean_fz,   index=clusters, columns=parcels).to_csv(
+            os.path.join(
+                partial_output_folder,
+                f"group_mean_cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.csv"
+            )
+        )
+        pd.DataFrame(median_fz, index=clusters, columns=parcels).to_csv(
+            os.path.join(
+                partial_output_folder,
+                f"group_median_cluster_by_mmp-parcel_partial_fisherz{run_tag}_{tag}.csv"
+            )
+        )
+
+        # Pearson r arrays
+        np.save(
+            os.path.join(
+                partial_output_folder,
+                f"group_mean_cluster_by_mmp-parcel_partial_r{run_tag}_{tag}.npy"
+            ),
+            mean_r,
+        )
+        np.save(
+            os.path.join(
+                partial_output_folder,
+                f"group_median_cluster_by_mmp-parcel_partial_r{run_tag}_{tag}.npy"
+            ),
+            median_r,
+        )
+
+        pd.DataFrame(mean_r,   index=clusters, columns=parcels).to_csv(
+            os.path.join(
+                partial_output_folder,
+                f"group_mean_cluster_by_mmp-parcel_partial_r{run_tag}_{tag}.csv"
+            )
+        )
+        pd.DataFrame(median_r, index=clusters, columns=parcels).to_csv(
+            os.path.join(
+                partial_output_folder,
+                f"group_median_cluster_by_mmp-parcel_partial_r{run_tag}_{tag}.csv"
+            )
+        )
+
+        # Compressed archive with all four arrays + metadata
+        np.savez_compressed(
+            os.path.join(
+                partial_output_folder,
+                f"group_partial_corr{run_tag}_{tag}.npz"
+            ),
+            mean_fz            = mean_fz,
+            median_fz          = median_fz,
+            mean_r             = mean_r,
+            median_r           = median_r,
+            n_subjects_loaded  = np.array(n_loaded),
+            subjects_loaded    = np.array([s for s in subjects if s not in missing]),
+            subjects_missing   = np.array(missing),
+            clusters           = np.array(clusters),
+            parcels            = np.array(parcels),
+            hemi               = np.array(label),
+            run                = np.array(run if run else "concatenated"),
+        )
+
+        print(f"  [{label}{run_tag}] Saved. Shape: {mean_fz.shape}\n")
+
+print("Done.")
+# ============================================================


### PR DESCRIPTION
fixed bug in fMRIpostaroma (mb requested instead of gb)
quality check outputs for all subjects regardless of xcp-d denoising
working on more neatly separating correlation computations from stats operation (e.g., averaging needs to be done on fisher-z outputs only)